### PR TITLE
Add table-based localization feature

### DIFF
--- a/Polyglot/Polyglot.xcodeproj/project.pbxproj
+++ b/Polyglot/Polyglot.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		22E990441BAAF9E40084D941 /* UIBarItem+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E990431BAAF9E40084D941 /* UIBarItem+Polyglot.swift */; };
 		22E990461BAB13820084D941 /* UINavigationItem+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E990451BAB13820084D941 /* UINavigationItem+Polyglot.swift */; };
 		22F496C41BA3195A00EE5EBA /* UILabel+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F496C31BA3195A00EE5EBA /* UILabel+Polyglot.swift */; };
+		49D53F791ED71FAB00C99548 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D53F781ED71FAB00C99548 /* Helpers.swift */; };
 		88490D591BAEDCF500469D4B /* NSViewController+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88490D581BAEDCF500469D4B /* NSViewController+Polyglot.swift */; };
 		88490D5D1BAEE20E00469D4B /* NSButton+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88490D5C1BAEE20E00469D4B /* NSButton+Polyglot.swift */; };
 		8861BEAF1BAD63850067DECF /* NSTextField+Polyglot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8861BEAE1BAD63850067DECF /* NSTextField+Polyglot.swift */; };
@@ -110,6 +111,7 @@
 				88A4AD081BB6A7570030C15C /* NSTableColumn+Polyglot.swift */,
 				2237DC381BB97A66005BB873 /* NSMenu+Polyglot.swift */,
 				2237DC3A1BB98218005BB873 /* NSMenuItem+Polyglot.swift */,
+				49D53F781ED71FAB00C99548 /* Helpers.swift */,
 				22C2884E1BA2D01C0004AED4 /* Supporting Files */,
 			);
 			path = Source;
@@ -242,6 +244,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				22F496C41BA3195A00EE5EBA /* UILabel+Polyglot.swift in Sources */,
+				49D53F791ED71FAB00C99548 /* Helpers.swift in Sources */,
 				22E990461BAB13820084D941 /* UINavigationItem+Polyglot.swift in Sources */,
 				22E71C3A1BA815AF000B39D3 /* UITextField+Polyglot.swift in Sources */,
 				224D58EB1BAC36B80040B007 /* UISearchBar+Polyglot.swift in Sources */,

--- a/Polyglot/Source/Helpers.swift
+++ b/Polyglot/Source/Helpers.swift
@@ -1,0 +1,34 @@
+//
+// Copyright (c) 2015 NEGU Soft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+private let tableNameDelimiters = (start: Character("["), end: "].")
+
+func LocalizedString(_ key: String, comment: String) -> String {
+    if let open = key.characters.first, open == tableNameDelimiters.start, let close = key.range(of: tableNameDelimiters.end) {
+        return NSLocalizedString(key[close.upperBound..<key.endIndex],
+                                 tableName: key[key.index(key.startIndex, offsetBy: 1)..<close.lowerBound],
+                                 comment: comment)
+    } else {
+        return NSLocalizedString(key, comment: comment)
+    }
+}

--- a/Polyglot/Source/NSButton+Polyglot.swift
+++ b/Polyglot/Source/NSButton+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSButton {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 
@@ -36,7 +36,7 @@ public extension NSButton {
     var alternateTitleKey: String {
         get { return "" }
         set {
-            self.alternateTitle = NSLocalizedString(newValue, comment:newValue)
+            self.alternateTitle = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSComboBox+Polyglot.swift
+++ b/Polyglot/Source/NSComboBox+Polyglot.swift
@@ -56,7 +56,7 @@ public extension NSComboBox {
             return item as AnyObject
         }
         if item is String {
-            return NSLocalizedString(key, comment:key) as AnyObject
+            return LocalizedString(key, comment:key) as AnyObject
         }
         return item as AnyObject
     }

--- a/Polyglot/Source/NSFormCell+Polyglot.swift
+++ b/Polyglot/Source/NSFormCell+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSFormCell {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 
@@ -36,7 +36,7 @@ public extension NSFormCell {
     var stringValueKey: String {
         get { return "" }
         set {
-            self.stringValue = NSLocalizedString(newValue, comment:newValue)
+            self.stringValue = LocalizedString(newValue, comment:newValue)
         }
     }
 
@@ -44,7 +44,7 @@ public extension NSFormCell {
     var placeholderKey: String {
         get { return "" }
         set {
-            self.placeholderString = NSLocalizedString(newValue, comment:newValue)
+            self.placeholderString = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSMenu+Polyglot.swift
+++ b/Polyglot/Source/NSMenu+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSMenu {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSMenuItem+Polyglot.swift
+++ b/Polyglot/Source/NSMenuItem+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSMenuItem {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSSegmentedControl+Polyglot.swift
+++ b/Polyglot/Source/NSSegmentedControl+Polyglot.swift
@@ -40,7 +40,7 @@ public extension NSSegmentedControl {
                 }
                 let key = keys[index].trimmingCharacters(in: spaceCharacterSet)
                 if (!key.isEmpty) {
-                    let label = NSLocalizedString(key, comment:key)
+                    let label = LocalizedString(key, comment:key)
                     self.setLabel(label, forSegment: index)
                 }
             }

--- a/Polyglot/Source/NSTabViewItem+Polyglot.swift
+++ b/Polyglot/Source/NSTabViewItem+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSTabViewItem {
     var labelKey: String {
         get { return "" }
         set {
-            self.label = NSLocalizedString(newValue, comment:newValue)
+            self.label = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSTableColumn+Polyglot.swift
+++ b/Polyglot/Source/NSTableColumn+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSTableColumn {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSTextField+Polyglot.swift
+++ b/Polyglot/Source/NSTextField+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSTextField {
     var titleKey: String {
         get { return "" }
         set {
-            self.stringValue = NSLocalizedString(newValue, comment:newValue)
+            self.stringValue = LocalizedString(newValue, comment:newValue)
         }
     }
 
@@ -37,10 +37,10 @@ public extension NSTextField {
         get { return "" }
         set {
             if #available(OSX 10.10, *) {
-                self.placeholderString = NSLocalizedString(newValue, comment:newValue)
+                self.placeholderString = LocalizedString(newValue, comment:newValue)
             } else {
                 if let cell = self.cell as? NSTextFieldCell {
-                    cell.placeholderString = NSLocalizedString(newValue, comment:newValue)
+                    cell.placeholderString = LocalizedString(newValue, comment:newValue)
                 }
             }
         }

--- a/Polyglot/Source/NSTextFieldCell+Polyglot.swift
+++ b/Polyglot/Source/NSTextFieldCell+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSTextFieldCell {
     var titleKey: String {
         get { return "" }
         set {
-            self.stringValue = NSLocalizedString(newValue, comment:newValue)
+            self.stringValue = LocalizedString(newValue, comment:newValue)
         }
     }
 
@@ -36,7 +36,7 @@ public extension NSTextFieldCell {
     var placeholderKey: String {
         get { return "" }
         set {
-            self.placeholderString = NSLocalizedString(newValue, comment:newValue)
+            self.placeholderString = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/NSViewController+Polyglot.swift
+++ b/Polyglot/Source/NSViewController+Polyglot.swift
@@ -28,7 +28,7 @@ public extension NSViewController {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/UIBarItem+Polyglot.swift
+++ b/Polyglot/Source/UIBarItem+Polyglot.swift
@@ -30,7 +30,7 @@ public extension UIBarItem {
         set {
             // Disable animations, it might be visible in some situations otherwise
             UIView.setAnimationsEnabled(false)
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
             UIView.setAnimationsEnabled(true)
         }
     }

--- a/Polyglot/Source/UIButton+Polyglot.swift
+++ b/Polyglot/Source/UIButton+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UIButton {
     var defaultTitleKey: String {
         get { return "" }
         set {
-            self.setTitle(NSLocalizedString(newValue, comment:newValue), for: UIControlState())
+            self.setTitle(LocalizedString(newValue, comment:newValue), for: UIControlState())
         }
     }
 
@@ -36,7 +36,7 @@ public extension UIButton {
     var highLightedTitleKey: String {
         get { return "" }
         set {
-            self.setTitle(NSLocalizedString(newValue, comment:newValue), for: .highlighted)
+            self.setTitle(LocalizedString(newValue, comment:newValue), for: .highlighted)
         }
     }
 
@@ -44,7 +44,7 @@ public extension UIButton {
     var selectedTitleKey: String {
         get { return "" }
         set {
-            self.setTitle(NSLocalizedString(newValue, comment:newValue), for: .selected)
+            self.setTitle(LocalizedString(newValue, comment:newValue), for: .selected)
         }
     }
 
@@ -52,7 +52,7 @@ public extension UIButton {
     var disabledTitleKey: String {
         get { return "" }
         set {
-            self.setTitle(NSLocalizedString(newValue, comment:newValue), for: .disabled)
+            self.setTitle(LocalizedString(newValue, comment:newValue), for: .disabled)
         }
     }
 }

--- a/Polyglot/Source/UILabel+Polyglot.swift
+++ b/Polyglot/Source/UILabel+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UILabel {
     var textKey: String {
         get { return "" }
         set {
-            self.text = NSLocalizedString(newValue, comment:newValue)
+            self.text = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/UINavigationItem+Polyglot.swift
+++ b/Polyglot/Source/UINavigationItem+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UINavigationItem {
     var titleKey: String {
         get { return "" }
         set {
-            self.title = NSLocalizedString(newValue, comment:newValue)
+            self.title = LocalizedString(newValue, comment:newValue)
         }
     }
     
@@ -36,7 +36,7 @@ public extension UINavigationItem {
     var promptKey: String {
         get { return "" }
         set {
-            self.prompt = NSLocalizedString(newValue, comment:newValue)
+            self.prompt = LocalizedString(newValue, comment:newValue)
         }
     }
     
@@ -45,10 +45,10 @@ public extension UINavigationItem {
         get { return "" }
         set {
             if let backBarButtonItem = self.backBarButtonItem {
-                backBarButtonItem.title = NSLocalizedString(newValue, comment:newValue)
+                backBarButtonItem.title = LocalizedString(newValue, comment:newValue)
             } else {
                 self.backBarButtonItem = UIBarButtonItem(
-                    title: NSLocalizedString(newValue, comment:newValue),
+                    title: LocalizedString(newValue, comment:newValue),
                     style: UIBarButtonItemStyle.plain,
                     target: nil,
                     action: nil

--- a/Polyglot/Source/UISearchBar+Polyglot.swift
+++ b/Polyglot/Source/UISearchBar+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UISearchBar {
     var textKey: String {
         get { return "" }
         set {
-            self.text = NSLocalizedString(newValue, comment:newValue)
+            self.text = LocalizedString(newValue, comment:newValue)
         }
     }
     
@@ -36,7 +36,7 @@ public extension UISearchBar {
     var placeholderKey: String {
         get { return "" }
         set {
-            self.placeholder = NSLocalizedString(newValue, comment:newValue)
+            self.placeholder = LocalizedString(newValue, comment:newValue)
         }
     }
     
@@ -44,7 +44,7 @@ public extension UISearchBar {
     var promptKey: String {
         get { return "" }
         set {
-            self.prompt = NSLocalizedString(newValue, comment:newValue)
+            self.prompt = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/UISegmentedControl+Polyglot.swift
+++ b/Polyglot/Source/UISegmentedControl+Polyglot.swift
@@ -40,7 +40,7 @@ public extension UISegmentedControl {
                 }
                 let key = keys[index].trimmingCharacters(in: spaceCharacterSet)
                 if (!key.isEmpty) {
-                    let title = NSLocalizedString(key, comment:key)
+                    let title = LocalizedString(key, comment:key)
                     self.setTitle(title, forSegmentAt: index)
                 }
             }

--- a/Polyglot/Source/UITextField+Polyglot.swift
+++ b/Polyglot/Source/UITextField+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UITextField {
     var textKey: String {
         get { return "" }
         set {
-            self.text = NSLocalizedString(newValue, comment:newValue)
+            self.text = LocalizedString(newValue, comment:newValue)
         }
     }
     
@@ -36,7 +36,7 @@ public extension UITextField {
     var placeholderKey: String {
         get { return "" }
         set {
-            self.placeholder = NSLocalizedString(newValue, comment:newValue)
+            self.placeholder = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/Polyglot/Source/UITextView+Polyglot.swift
+++ b/Polyglot/Source/UITextView+Polyglot.swift
@@ -28,7 +28,7 @@ public extension UITextView {
     var textKey: String {
         get { return "" }
         set {
-            self.text = NSLocalizedString(newValue, comment:newValue)
+            self.text = LocalizedString(newValue, comment:newValue)
         }
     }
 }

--- a/PolyglotLocalization.podspec
+++ b/PolyglotLocalization.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
 
+  s.source_files     = 'Polyglot/Source/Helpers.swift'
   s.ios.source_files = 'Polyglot/Source/UI*.swift'
   s.osx.source_files = 'Polyglot/Source/NS*.swift'
 


### PR DESCRIPTION
Hi there,

Great library! Just discovered this today doing a localization project, and it really helps out. However, I noticed it doesn't provide any support for tabled localizations. For example, I'm localizing a lot of storyboard where the table name with be basename of (for example) `StoryboardName.storyboard`, giving the table name `StoryboardName`. In order to support this, I've added additional properties with the prefix `table...` as you can see. The format I've chosen so far is that the tableName is a prefix, separated from the rest of the key by a period. Then the rest of the value is used as the tabled key, and can include further periods (the rest of the array is joined if there are more components).

I wasn't sure how to handle the CSV properties. Actually the same approach could be used, but it would be better to strip out the repeated code to `fileprivate` helpers or something. Since I would call this an initial _quick and dirty_ implementation (on a deadline here!), I thought it would be better to submit what I've done so far and get your feedback.

Thanks!